### PR TITLE
Fix addTimesItem

### DIFF
--- a/app/src/main/java/de/euhm/jlt/ViewSectionFragment.kt
+++ b/app/src/main/java/de/euhm/jlt/ViewSectionFragment.kt
@@ -267,10 +267,10 @@ class ViewSectionFragment : ListFragment() {
     }
 
     fun addTimesItem(times: Times) {
-        mDatasource.createTimes(times)
+        val timesCreated = mDatasource.createTimes(times)
         val adapter = listAdapter as? ViewTimesListAdapter?
         adapter?.setNotifyOnChange(false) // do not notify changes yet
-        adapter?.add(times)
+        adapter?.add(timesCreated)
         adapter?.sort()
         adapter?.notifyDataSetChanged() // now update the changed data
         updateInfoLine()


### PR DESCRIPTION
addTimesItem did not add the created db id to the shown adapter list resulting in double entries if these are changed once again